### PR TITLE
Quarkus 1.0.1 updates and add podman as build option

### DIFF
--- a/hello/quarked/buildNativeLinux.sh
+++ b/hello/quarked/buildNativeLinux.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
-export GRAALVM_HOME=/usr/lib/jvm/graalvm/
+if [ -z $GRAALVM_HOME ]; then
+    export GRAALVM_HOME=~/tools/graalvm-ce-1.0.0-rc15/Contents/Home/
+fi 
 
 # Mac Native
 # mvn package -Pnative

--- a/hello/quarked/buildNativeLinux.sh
+++ b/hello/quarked/buildNativeLinux.sh
@@ -1,9 +1,31 @@
 #!/bin/bash
 
-export GRAALVM_HOME=~/tools/graalvm-ce-1.0.0-rc15/Contents/Home/
+export GRAALVM_HOME=/usr/lib/jvm/graalvm/
 
 # Mac Native
 # mvn package -Pnative
 
 # Linux Native
-mvn package -Pnative -Dnative-image.docker-build=true -DskipTests
+
+# set default runtime to docker
+runtime='docker'
+
+usage () {
+    echo "usage: ./buildNativeLinux.sh [-r docker|podman]"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -r | --runtime )        shift
+                                runtime=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+mvn package -Pnative -Dnative-image.docker-build=true -Dquarkus.native.container-runtime=${runtime} -DskipTests

--- a/hello/quarked/pom.xml
+++ b/hello/quarked/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <project>
     <modelVersion>4.0.0</modelVersion>
 
@@ -6,12 +6,18 @@
     <artifactId>quarked</artifactId>
     <version>1.0.0</version>
 
-    <properties>        
-        <quarkus.version>0.12.0</quarkus.version>
-        <surefire.version>2.22.0</surefire.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <properties>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <quarkus-plugin.version>1.0.1.Final</quarkus-plugin.version>
+        <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.version>1.0.1.Final</quarkus.platform.version>
+        <quarkus.version>1.0.1.Final</quarkus.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <surefire-plugin.version>2.22.1</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -19,18 +25,49 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom</artifactId>
-                <scope>import</scope>
-                <type>pom</type>
                 <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -46,38 +83,8 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Testing: -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-    </dependencies>
-
     <profiles>
-
         <profile>
-            <!-- Optionally activate this profile to compile the demo into native! -->
             <id>native</id>
             <activation>
                 <property>
@@ -95,13 +102,15 @@
                                 <goals>
                                     <goal>native-image</goal>
                                 </goals>
+                                <configuration>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.1</version>
+                        <version>${surefire-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -119,7 +128,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
-    
+
 </project>


### PR DESCRIPTION
Update the Quarkus version of to the quarked sub-project to quarkus 1.0.1 since I had errors running the native build with GraalVM 19.2.1 . 

Also adding Podman as an alternative option to the BuildNativeLinux.sh script